### PR TITLE
bugfix: #140: Failure to fallback when the Gemini API return 400 status code

### DIFF
--- a/main.py
+++ b/main.py
@@ -1469,6 +1469,11 @@ class ModelRequestHandler:
                 if is_debug:
                     import traceback
                     traceback.print_exc()
+                
+                # Add a specific check for API key invalid error to force a retry
+                if status_code == 400 and ("'reason': 'API_KEY_INVALID'" in error_message or "API key not valid" in error_message):
+                    continue
+
                 if auto_retry and (status_code not in [400, 413] or urlparse(provider.get('base_url', '')).netloc == 'models.inference.ai.azure.com'):
                     continue
                 else:


### PR DESCRIPTION
Bugfix for issue #140 

This bug reproduced and verified has been fixed:

```
2025-07-08 01:59:09,246 - uni-api - INFO - provider: gemini      model: gemini-2.5-pro-think-32768-search engine: gemini        role: admin
2025-07-08 01:59:09,472 - uni-api - ERROR - Error 400 with provider gemini API key: AIzaSyDxYdvN2qZi0NjEBrbbPwwfD7rMTFK7KaU: [{'error': {'code': 400, 'message': 'API key not valid. Please pass a valid API key.', 'status': 'INVALID_ARGUMENT', 'details': [{'@type': 'type.googleapis.com/google.rpc.ErrorInfo', 'reason': 'API_KEY_INVALID', 'domain': 'googleapis.com', 'metadata': {'service': 'generativelanguage.googleapis.com'}
2025-07-08 01:59:09,472 - uni-api - INFO - provider: gemini      model: gemini-2.5-pro-think-32768-search engine: gemini        role: admin
INFO:     211.22.161.135:0 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/086e5d4f-3170-4e32-81c3-a9861dc33e9a" />
