### PR TITLE
修正weighted_round_robin和all混用无效的问题

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -130,10 +130,20 @@ async def update_config(config_data, use_config_url=False):
                         if model_name in model_dict.keys():
                             weights_dict.update({provider_name + "/" + model_name: int(value)})
                         elif model_name == "*":
-                            weights_dict.update({provider_name + "/" + model_name: int(value) for model_item in model_dict.keys()})
+                            for model_item in model_dict.keys():
+                                weights_dict.update({provider_name + "/" + model_item: int(value)})
 
                     models.append(key)
-                if isinstance(model, str):
+                elif isinstance(model, str):
+                    # 处理字符串格式的模型配置
+                    if model == "all":
+                        # 如果有权重配置，为所有模型设置默认权重1
+                        if weights_dict or any(isinstance(m, dict) for m in api_key.get('model')):
+                            for provider_item in config_data["providers"]:
+                                model_dict = get_model_dict(provider_item)
+                                for model_item in model_dict.keys():
+                                    if f"{provider_item['provider']}/{model_item}" not in weights_dict:
+                                        weights_dict.update({f"{provider_item['provider']}/{model_item}": 1})
                     models.append(model)
             if weights_dict:
                 config_data['api_keys'][index]['weights'] = weights_dict


### PR DESCRIPTION
这个修改解决了几个关键问题：

 1 修复了 * 通配符的权重展开逻辑：原代码中 weights_dict.update({provider_name + "/" + model_name: int(value) for model_item in model_dict.keys()}) 实际上只会为一个模型设置权重，现在改为正确的循环展开。
 2 支持 all 与权重配置共存：当配置中同时存在权重模型和 all 时，会为所有未配置权重的模型设置默认权重1。
 3 保持向后兼容性：不影响现有的纯权重配置或纯字符串配置。

现在你的配置可以正常工作：


api_keys:
  - api: sk-xxx model: - all - gemini/*: 9 preferences: SCHEDULING_ALGORITHM: weighted_round_robin AUTO_RETRY: true


这样配置后：

 • gemini/* 下的所有模型都会有权重9
 • 其他所有模型会有默认权重1
 • 权重轮询算法会按照这些权重比例分配请求