### PR TITLE
fix: 修复非流式响应的 usage 统计缺失问题（token 数据为 0）

### DIFF
--- a/main.py
+++ b/main.py
@@ -1422,6 +1422,13 @@ async def process_request(
                     first_element = await anext(wrapped_generator)
                     first_element = first_element.lstrip("data: ")
                     decoded_element = await asyncio.to_thread(json.loads, first_element)
+
+                    # 提取 usage 信息到 current_info
+                    usage_obj = decoded_element.get("usage") or {}
+                    current_info["prompt_tokens"] = usage_obj.get("prompt_tokens") or usage_obj.get("input_tokens") or 0
+                    current_info["completion_tokens"] = usage_obj.get("completion_tokens") or usage_obj.get("output_tokens") or 0
+                    current_info["total_tokens"] = usage_obj.get("total_tokens") or 0
+
                     encoded_element = await asyncio.to_thread(json.dumps, decoded_element)
                     response = StarletteStreamingResponse(iter([encoded_element]), media_type="application/json")
 


### PR DESCRIPTION
- 问题：非流式响应的 token 统计写入数据库时为 0
- 原因：解析 JSON 后未提取 usage 字段到 current_info
- 修复：在 main.py:1426-1430 添加 usage 提取逻辑（5 行代码）
- 效果：非流式请求 token 统计正常，
                                                                                                                    
影响范围：所有非流式请求（stream=false）                                                                          
兼容性：支持所有模型（gpt/gemini/claude/codex等）