### PR TITLE
Fix gemini2.5 reasoning.effort

### DIFF
--- a/test/test_post_body_parameter_overrides.py
+++ b/test/test_post_body_parameter_overrides.py
@@ -437,3 +437,117 @@ def test_vertex_gemini_reasoning_effort_overrides_post_body_thinking_level():
     assert payload["generationConfig"]["maxOutputTokens"] == 65535
     assert payload["generationConfig"]["thinkingConfig"]["includeThoughts"] is True
     assert payload["generationConfig"]["thinkingConfig"]["thinkingLevel"] == "minimal"
+
+
+def _gemini_provider(model):
+    return {
+        "provider": "gemini",
+        "base_url": "https://generativelanguage.googleapis.com/v1beta",
+        "api": "test-key",
+        "model": [model],
+    }
+
+
+def _vertex_gemini_provider(model):
+    return {
+        "provider": "vertex-gemini",
+        "base_url": "https://google-vertex-ai.example.com",
+        "api": "test-key",
+        "project_id": "test-project",
+        "model": [model],
+    }
+
+
+def test_gemini_2_5_flash_reasoning_none_disables_thinking():
+    request = RequestModel(
+        model="gemini-2.5-flash",
+        messages=[{"role": "user", "content": "hello"}],
+        reasoning={"effort": "none"},
+        stream=False,
+    )
+
+    _, _, payload = asyncio.run(get_payload(request, "gemini", _gemini_provider("gemini-2.5-flash"), api_key="test-key"))
+
+    assert payload["generationConfig"]["thinkingConfig"] == {
+        "includeThoughts": False,
+        "thinkingBudget": 0,
+    }
+    assert "reasoning" not in payload
+    assert "reasoning_effort" not in payload
+
+
+def test_gemini_2_5_pro_reasoning_none_uses_minimum_budget():
+    request = RequestModel(
+        model="gemini-2.5-pro",
+        messages=[{"role": "user", "content": "hello"}],
+        reasoning={"effort": "none"},
+        stream=False,
+    )
+
+    _, _, payload = asyncio.run(get_payload(request, "gemini", _gemini_provider("gemini-2.5-pro"), api_key="test-key"))
+
+    assert payload["generationConfig"]["thinkingConfig"] == {
+        "includeThoughts": True,
+        "thinkingBudget": 128,
+    }
+
+
+def test_gemini_2_5_flash_lite_reasoning_none_is_explicit_zero():
+    request = RequestModel(
+        model="gemini-2.5-flash-lite",
+        messages=[{"role": "user", "content": "hello"}],
+        reasoning={"effort": "none"},
+        stream=False,
+    )
+
+    _, _, payload = asyncio.run(get_payload(request, "gemini", _gemini_provider("gemini-2.5-flash-lite"), api_key="test-key"))
+
+    assert payload["generationConfig"]["thinkingConfig"] == {
+        "includeThoughts": False,
+        "thinkingBudget": 0,
+    }
+
+
+def test_gemini_2_5_reasoning_effort_maps_to_quarter_budgets():
+    cases = [
+        ("gemini-2.5-pro", "low", 8192),
+        ("gemini-2.5-pro", "medium", 16384),
+        ("gemini-2.5-pro", "high", 24576),
+        ("gemini-2.5-pro", "extra_high", 32768),
+        ("gemini-2.5-flash", "low", 6144),
+        ("gemini-2.5-flash", "medium", 12288),
+        ("gemini-2.5-flash", "high", 18432),
+        ("gemini-2.5-flash", "xhight", 24576),
+        ("gemini-2.5-flash-lite", "low", 6144),
+        ("gemini-2.5-flash-lite", "extra-high", 24576),
+    ]
+
+    for model, effort, expected_budget in cases:
+        request = RequestModel(
+            model=model,
+            messages=[{"role": "user", "content": "hello"}],
+            reasoning_effort=effort,
+            stream=False,
+        )
+
+        _, _, payload = asyncio.run(get_payload(request, "gemini", _gemini_provider(model), api_key="test-key"))
+
+        assert payload["generationConfig"]["thinkingConfig"]["includeThoughts"] is True
+        assert payload["generationConfig"]["thinkingConfig"]["thinkingBudget"] == expected_budget
+        assert "reasoning_effort" not in payload
+
+
+def test_vertex_gemini_2_5_flash_reasoning_none_disables_thinking():
+    request = RequestModel(
+        model="gemini-2.5-flash",
+        messages=[{"role": "user", "content": "hello"}],
+        reasoning={"effort": "none"},
+        stream=False,
+    )
+
+    _, _, payload = asyncio.run(get_payload(request, "vertex-gemini", _vertex_gemini_provider("gemini-2.5-flash"), api_key="test-key"))
+
+    assert payload["generationConfig"]["thinkingConfig"] == {
+        "includeThoughts": False,
+        "thinkingBudget": 0,
+    }

--- a/uni_api/providers/payloads.py
+++ b/uni_api/providers/payloads.py
@@ -179,6 +179,19 @@ def _request_reasoning_effort(request: RequestModel) -> str | None:
     effort = str(effort).strip().lower()
     return effort or None
 
+def _normalize_reasoning_effort(effort: str | None) -> str | None:
+    if not effort:
+        return None
+    effort = str(effort).strip().lower().replace("-", "_")
+    aliases = {
+        "xhigh": "extra_high",
+        "x_high": "extra_high",
+        "xhight": "extra_high",
+        "x_hight": "extra_high",
+        "extra": "extra_high",
+    }
+    return aliases.get(effort, effort)
+
 def _gemini_2_5_thinking_budget_from_request_model(request_model: str, original_model: str) -> int | None:
     match = re.match(r".*-think-(-?\d+)", request_model)
     if not match:
@@ -207,6 +220,31 @@ def _gemini_2_5_thinking_budget_from_request_model(request_model: str, original_
         return 24576
     return val if val >= 0 else 0
 
+def _gemini_2_5_thinking_budget_from_request(request: RequestModel, original_model: str) -> int | None:
+    reasoning_effort = _normalize_reasoning_effort(_request_reasoning_effort(request))
+    if not reasoning_effort:
+        return _gemini_2_5_thinking_budget_from_request_model(request.model, original_model)
+
+    if "gemini-2.5-pro" in original_model:
+        if reasoning_effort == "none":
+            return 128
+        max_budget = 32768
+    elif "gemini-2.5-flash" in original_model:
+        if reasoning_effort == "none":
+            return 0
+        max_budget = 24576
+    else:
+        return _gemini_2_5_thinking_budget_from_request_model(request.model, original_model)
+
+    effort_budget = {
+        "minimal": max_budget // 4,
+        "low": max_budget // 4,
+        "medium": max_budget // 2,
+        "high": max_budget * 3 // 4,
+        "extra_high": max_budget,
+    }
+    return effort_budget.get(reasoning_effort)
+
 def _is_gemini_3_model_name(model_name: str | None) -> bool:
     if not model_name:
         return False
@@ -231,15 +269,17 @@ def _is_gemini_3_pro_model(request_model: str, original_model: str) -> bool:
 
 def _gemini_3_thinking_level_from_request(request: RequestModel, original_model: str) -> str | None:
     is_gemini_3_pro = _is_gemini_3_pro_model(request.model, original_model)
-    reasoning_effort = _request_reasoning_effort(request)
+    reasoning_effort = _normalize_reasoning_effort(_request_reasoning_effort(request))
     if reasoning_effort:
         if is_gemini_3_pro:
-            if reasoning_effort == "high":
+            if reasoning_effort in {"high", "extra_high"}:
                 return "high"
             if reasoning_effort in {"minimal", "low", "medium"}:
                 return "low"
         elif reasoning_effort in {"minimal", "low", "medium", "high"}:
             return reasoning_effort
+        elif reasoning_effort == "extra_high":
+            return "high"
 
     match = re.match(r".*-think-(-?\d+)", request.model)
     if match:
@@ -296,7 +336,7 @@ def _apply_explicit_gemini_request_controls(
     generation_config = payload.setdefault("generationConfig", {})
 
     if "gemini-2.5" in original_model and "-image" not in original_model and "preview-tts" not in original_model.lower():
-        budget = _gemini_2_5_thinking_budget_from_request_model(request.model, original_model)
+        budget = _gemini_2_5_thinking_budget_from_request(request, original_model)
         if budget is not None:
             thinking_config = generation_config.get("thinkingConfig")
             if not isinstance(thinking_config, dict):
@@ -547,6 +587,7 @@ async def get_gemini_payload(request, engine, provider, api_key=None):
         'modalities',
         'audio',
         'reasoning',
+        'reasoning_effort',
     ]
     generation_config = {}
 
@@ -796,6 +837,7 @@ async def get_vertex_gemini_payload(request, engine, provider, api_key=None):
         'modalities',
         'audio',
         'reasoning',
+        'reasoning_effort',
     ]
     generation_config = {}
 
@@ -833,7 +875,7 @@ async def get_vertex_gemini_payload(request, engine, provider, api_key=None):
     # Gemini 2.5 系列的 thinkingConfig 处理
     # Note: preview TTS models do not support thinkingConfig.
     if "gemini-2.5" in original_model and "preview-tts" not in original_model.lower():
-        budget = _gemini_2_5_thinking_budget_from_request_model(request.model, original_model)
+        budget = _gemini_2_5_thinking_budget_from_request(request, original_model)
         if budget is not None:
             payload["generationConfig"]["thinkingConfig"] = {
                 "includeThoughts": True if budget else False,


### PR DESCRIPTION
## 🚀 Fix gemini2.5 reasoning.effort

Gemini 2.5 现在支持 `reasoning={"effort": "none"}` 和 `reasoning_effort="low|medium|high|extra_high"`。

### 📌 思考预算映射规则

*   **2.5 Pro**：`none` -> `thinkingBudget 128`（注意：不能关闭）。
*   **2.5 Flash / Flash-Lite**：`none` -> `thinkingBudget 0`（显式关闭）。
*   **2.5 Pro 映射（按 32768 四档映射）**：
    *   `low` -> **8192**
    *   `medium` -> **16384**
    *   `high` -> **24576**
    *   `extra_high` -> **32768**
*   **2.5 Flash / Flash-Lite 映射（按 24576 四档映射）**：
    *   `low` -> **6144**
    *   `medium` -> **12288**
    *   `high` -> **18432**
    *   `extra_high` -> **24576**

> 💡 **兼容性说明**：兼容了 `extra_high`、`extra-high`、`xhigh`、`xhight` 这些最高档写法。
> `reasoning_effort` 不再透传到 Gemini 原生 payload 顶层，只转换成 `generationConfig.thinkingConfig`。

---

### 🧪 测试与验证

*   **测试代码追加**：测试补在 `test_post_body_parameter_overrides.py` (line 440)，覆盖了 Gemini 和 Vertex Gemini 的 2.5 Flash/Pro/Flash-Lite 行为。
*   **本地编译与验证**：
    ```bash
    python -m py_compile uni_api\providers\payloads.py test\test_post_body_parameter_overrides.py
    ```
    👉 **结果**：验证通过。
*   **冒烟测试**：用临时 stub 绕过本机缺失的 `httpx_socks` 后，payload 冒烟验证通过。
*   **环境局限**：没能跑完整 pytest（本机没有 `uv`，全局 Python 也没有 `pytest`）。

---

### 📊 测试结果

```bash
python -m pytest test\test_post_body_parameter_overrides.py