### PR TITLE
Make Vertex AI region configurable and default to global

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ providers:
 
   - provider: vertex
     project_id: gen-lang-client-xxxxxxxxxxxxxx # Description: Your Google Cloud project ID. Format: String, usually composed of lowercase letters, numbers, and hyphens. How to obtain: You can find your project ID in the project selector of the Google Cloud Console.
+    region: global # Vertex AI region, optional and defaults to global. Set one explicit region such as us-central1 when needed.
     private_key: "-----BEGIN PRIVATE KEY-----\nxxxxx\n-----END PRIVATE" # Description: Private key for Google Cloud Vertex AI service account. Format: A JSON formatted string containing the private key information of the service account. How to obtain: Create a service account in Google Cloud Console, generate a JSON formatted key file, and then set its content as the value of this environment variable.
     client_email: xxxxxxxxxx@xxxxxxx.gserviceaccount.com # Description: Email address of the Google Cloud Vertex AI service account. Format: Usually a string like "service-account-name@project-id.iam.gserviceaccount.com". How to obtain: Generated when creating a service account, or you can view the service account details in the "IAM and Admin" section of the Google Cloud Console.
     model:

--- a/README.md
+++ b/README.md
@@ -22,11 +22,10 @@ For personal use, one/new-api is too complex with many commercial features that 
 - Simultaneously supports Anthropic, Gemini, Vertex AI, Azure, AWS, xai, Cohere, Groq, Cloudflare, [0-0.pro](https://0-0.pro/r/uniapi). Vertex simultaneously supports Claude and Gemini API.
 - Support OpenAI, Anthropic, Gemini, Vertex, Azure, AWS, xai native tool use function calls.
 - Support OpenAI, Anthropic, Gemini, Vertex, Azure, AWS, xai native image recognition API.
-- Support four types of load balancing.
+- Support three types of load balancing.
   1. Supports channel-level weighted load balancing, allowing requests to be distributed according to different channel weights. It is not enabled by default and requires configuring channel weights.
-  2. Support Vertex regional load balancing and high concurrency, which can increase Gemini and Claude concurrency by up to (number of APIs * number of regions) times. Automatically enabled without additional configuration.
-  3. Except for Vertex region-level load balancing, all APIs support channel-level sequential load balancing, enhancing the immersive translation experience. It is not enabled by default and requires configuring `SCHEDULING_ALGORITHM` as `round_robin`.
-  4. Support automatic API key-level round-robin load balancing for multiple API Keys in a single channel.
+  2. All APIs support channel-level sequential load balancing, enhancing the immersive translation experience. It is not enabled by default and requires configuring `SCHEDULING_ALGORITHM` as `round_robin`.
+  3. Support automatic API key-level round-robin load balancing for multiple API Keys in a single channel.
 - Support automatic retry, when an API channel response fails, automatically retry the next API channel.
 - Support channel cooling: When an API channel response fails, the channel will automatically be excluded and cooled for a period of time, and requests to the channel will be stopped. After the cooling period ends, the model will automatically be restored until it fails again, at which point it will be cooled again.
 - Support fine-grained model timeout settings, allowing different timeout durations for each model.

--- a/README_CN.md
+++ b/README_CN.md
@@ -22,11 +22,10 @@
 - 同时支持 Anthropic、Gemini、Vertex AI、Azure、AWS、xai、Cohere、Groq、Cloudflare、[0-0.pro](https://0-0.pro/r/uniapi)。Vertex 同时支持 Claude 和 Gemini API。
 - 支持 OpenAI、 Anthropic、Gemini、Vertex、Azure、AWS、xai 原生 tool use 函数调用。
 - 支持 OpenAI、Anthropic、Gemini、Vertex、Azure、AWS、xai 原生识图 API。
-- 支持四种负载均衡。
+- 支持三种负载均衡。
   1. 支持渠道级加权负载均衡，可以根据不同的渠道权重分配请求。默认不开启，需要配置渠道权重。
-  2. 支持 Vertex 区域级负载均衡，支持 Vertex 高并发，最高可将 Gemini，Claude 并发提高 （API数量 * 区域数量） 倍。自动开启不需要额外配置。
-  3. 除了 Vertex 区域级负载均衡，所有 API 均支持渠道级顺序负载均衡，提高沉浸式翻译体验。默认不开启，需要配置 `SCHEDULING_ALGORITHM` 为 `round_robin`。
-  4. 支持单个渠道多个 API Key 自动开启 API key 级别的轮训负载均衡。
+  2. 所有 API 均支持渠道级顺序负载均衡，提高沉浸式翻译体验。默认不开启，需要配置 `SCHEDULING_ALGORITHM` 为 `round_robin`。
+  3. 支持单个渠道多个 API Key 自动开启 API key 级别的轮询负载均衡。
 - 支持自动重试，当一个 API 渠道响应失败时，自动重试下一个 API 渠道。
 - 支持渠道冷却，当一个 API 渠道响应失败时，会自动将该渠道排除冷却一段时间，不再请求该渠道，冷却时间结束后，会自动将该模型恢复，直到再次请求失败，会重新冷却。
 - 支持细粒度的模型超时时间设置，可以为每个模型设置不同的超时时间。

--- a/README_CN.md
+++ b/README_CN.md
@@ -143,6 +143,7 @@ providers:
 
   - provider: vertex
     project_id: gen-lang-client-xxxxxxxxxxxxxx #    描述： 您的Google Cloud项目ID。格式： 字符串，通常由小写字母、数字和连字符组成。获取方式： 在Google Cloud Console的项目选择器中可以找到您的项目ID。
+    region: global # Vertex AI 区域，选填，默认为 global。如需指定区域，可设置为 us-central1 等单个区域。
     private_key: "-----BEGIN PRIVATE KEY-----\nxxxxx\n-----END PRIVATE" # 描述： Google Cloud Vertex AI服务账号的私钥。格式： 一个 JSON 格式的字符串，包含服务账号的私钥信息。获取方式： 在 Google Cloud Console 中创建服务账号，生成JSON格式的密钥文件，然后将其内容设置为此环境变量的值。
     client_email: xxxxxxxxxx@xxxxxxx.gserviceaccount.com # 描述： Google Cloud Vertex AI 服务账号的电子邮件地址。格式： 通常是形如 "service-account-name@project-id.iam.gserviceaccount.com" 的字符串。获取方式： 在创建服务账号时生成，也可以在 Google Cloud Console 的"IAM与管理"部分查看服务账号详情获得。
     model:

--- a/test/test_config_runtime.py
+++ b/test/test_config_runtime.py
@@ -52,6 +52,25 @@ def test_validate_config_data_error_message_identifies_missing_provider_field():
     assert "Field required" in message
 
 
+def test_validate_config_data_rejects_multiple_vertex_regions():
+    with pytest.raises(Exception) as exc_info:
+        validate_config_data(
+            {
+                "providers": [
+                    {
+                        "provider": "vertex",
+                        "project_id": "test-project",
+                        "region": ["global", "us-west1"],
+                        "model": ["gemini-3.1-flash-lite"],
+                    }
+                ],
+                "api_keys": [],
+            }
+        )
+
+    assert "providers.0.region" in str(exc_info.value)
+
+
 def test_compile_runtime_config_accepts_empty_config():
     config = validate_config_data({})
     runtime = compile_runtime_config(config, [], models_list={})

--- a/test/test_provider_adapters.py
+++ b/test/test_provider_adapters.py
@@ -379,7 +379,8 @@ async def test_provider_adapter_request_golden_matrix():
             },
             "upstream-key",
             lambda request: (
-                "/projects/project-a/locations/us-east5/" in request.url
+                request.url.startswith("https://aiplatform.googleapis.com/")
+                and "/projects/project-a/locations/global/" in request.url
                 and "/publishers/anthropic/models/claude-3-haiku:streamRawPredict" in request.url
                 and request.payload["messages"][0]["content"] == "hello"
             ),

--- a/test/test_vertex_region.py
+++ b/test/test_vertex_region.py
@@ -2,6 +2,7 @@ import asyncio
 
 from core.models import RequestModel
 from uni_api.providers.payloads import get_vertex_claude_payload, get_vertex_gemini_payload
+from uni_api.routing.core import build_api_key_models_map, get_right_order_providers
 
 
 def _request(model):
@@ -56,3 +57,38 @@ def test_vertex_claude_uses_same_region_setting():
         "https://europe-west1-aiplatform.googleapis.com/v1/projects/test-project/locations/europe-west1/"
         "publishers/anthropic/models/claude-sonnet-4-5@20250929:streamRawPredict"
     )
+
+
+def test_vertex_region_survives_provider_routing_view():
+    config = {
+        "providers": [
+            {
+                "provider": "vertex",
+                "base_url": "https://aiplatform.googleapis.com",
+                "project_id": "test-project",
+                "region": "us-west1",
+                "model": ["gemini-3.1-flash-lite"],
+            }
+        ],
+        "api_keys": [
+            {
+                "api": "sk-test",
+                "model": ["vertex/gemini-3.1-flash-lite"],
+            }
+        ],
+    }
+    api_list = ["sk-test"]
+    models_list = build_api_key_models_map(config, api_list)
+
+    providers = asyncio.run(
+        get_right_order_providers(
+            "gemini-3.1-flash-lite",
+            config,
+            0,
+            "fixed_priority",
+            api_list,
+            models_list,
+        )
+    )
+
+    assert providers[0]["region"] == "us-west1"

--- a/test/test_vertex_region.py
+++ b/test/test_vertex_region.py
@@ -1,0 +1,58 @@
+import asyncio
+
+from core.models import RequestModel
+from uni_api.providers.payloads import get_vertex_claude_payload, get_vertex_gemini_payload
+
+
+def _request(model):
+    return RequestModel(model=model, messages=[{"role": "user", "content": "hello"}], stream=False)
+
+
+def test_vertex_gemini_defaults_to_global_region():
+    provider = {
+        "provider": "vertex",
+        "base_url": "https://aiplatform.googleapis.com",
+        "project_id": "test-project",
+        "model": ["gemini-3.5-flash"],
+    }
+
+    url, _, _ = asyncio.run(get_vertex_gemini_payload(_request("gemini-3.5-flash"), "vertex-gemini", provider))
+
+    assert url == (
+        "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/"
+        "publishers/google/models/gemini-3.5-flash:generateContent"
+    )
+
+
+def test_vertex_gemini_uses_explicit_region():
+    provider = {
+        "provider": "vertex",
+        "base_url": "https://aiplatform.googleapis.com",
+        "project_id": "test-project",
+        "region": "us-central1",
+        "model": ["gemini-3.5-flash"],
+    }
+
+    url, _, _ = asyncio.run(get_vertex_gemini_payload(_request("gemini-3.5-flash"), "vertex-gemini", provider))
+
+    assert url == (
+        "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/"
+        "publishers/google/models/gemini-3.5-flash:generateContent"
+    )
+
+
+def test_vertex_claude_uses_same_region_setting():
+    provider = {
+        "provider": "vertex",
+        "base_url": "https://aiplatform.googleapis.com",
+        "project_id": "test-project",
+        "region": "europe-west1",
+        "model": ["claude-sonnet-4-5@20250929"],
+    }
+
+    url, _, _ = asyncio.run(get_vertex_claude_payload(_request("claude-sonnet-4-5@20250929"), "vertex-claude", provider))
+
+    assert url == (
+        "https://europe-west1-aiplatform.googleapis.com/v1/projects/test-project/locations/europe-west1/"
+        "publishers/anthropic/models/claude-sonnet-4-5@20250929:streamRawPredict"
+    )

--- a/uni_api/config/schema.py
+++ b/uni_api/config/schema.py
@@ -12,6 +12,7 @@ class ProviderConfig(BaseModel):
     base_url: str = ""
     api: Any = None
     model: Any = None
+    region: str = "global"
     preferences: dict[str, Any] = Field(default_factory=dict)
     exclude_endpoints: Any = None
 

--- a/uni_api/providers/payloads.py
+++ b/uni_api/providers/payloads.py
@@ -24,14 +24,6 @@ from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
 from core.models import RequestModel, Message
 from core.utils import (
-    c3s,
-    c3o,
-    c3h,
-    c35s,
-    c4,
-    gemini1,
-    gemini_preview,
-    gemini2_5_pro_exp,
     BaseAPI,
     safe_get,
     get_engine,
@@ -734,6 +726,22 @@ async def get_access_token(client_email, private_key):
         response.raise_for_status()
         return response.json()["access_token"]
 
+
+def _get_vertex_region(provider):
+    return str(provider.get("region") or "global").strip() or "global"
+
+
+def _get_vertex_model_url(provider, project_id, publisher, model, stream):
+    region = _get_vertex_region(provider)
+    base_url = (provider.get("base_url") or "https://aiplatform.googleapis.com").rstrip("/")
+    if "google-vertex-ai" not in base_url:
+        base_url = (
+            "https://aiplatform.googleapis.com"
+            if region == "global"
+            else f"https://{region}-aiplatform.googleapis.com"
+        )
+    return f"{base_url}/v1/projects/{project_id}/locations/{region}/publishers/{publisher}/models/{model}:{stream}"
+
 async def get_vertex_gemini_payload(request, engine, provider, api_key=None):
     headers = {
         'Content-Type': 'application/json'
@@ -752,33 +760,17 @@ async def get_vertex_gemini_payload(request, engine, provider, api_key=None):
     original_model = model_dict[request.model]
     # search_tool = None
 
-    # https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-0-flash?hl=zh-cn
-    pro_models = ["gemini-2.5"]
-    global_models = ["gemini-2.5-flash-image-preview", "gemini-3-pro", "gemini-3-flash", "gemini-3.1-pro"]
-    if any(global_model in original_model for global_model in global_models):
-        location = gemini_preview
-    elif any(pro_model in original_model for pro_model in pro_models):
-        location = gemini2_5_pro_exp
-    else:
-        location = gemini1
-
     if api_key is not None and len(api_key) > 2 and api_key[2] == ".":
         base = (provider.get("base_url") or "https://aiplatform.googleapis.com").rstrip("/")
         url = f"{base}/v1/publishers/google/models/{original_model}:{gemini_stream}?key={api_key}"
         headers.pop("Authorization", None)
-    elif "google-vertex-ai" in provider.get("base_url", "") or any(global_model in original_model for global_model in global_models):
-        url = provider.get("base_url").rstrip('/') + "/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/google/models/{MODEL_ID}:{stream}".format(
-            LOCATION=await location.next(),
-            PROJECT_ID=project_id,
-            MODEL_ID=original_model,
-            stream=gemini_stream
-        )
     else:
-        url = "https://{LOCATION}-aiplatform.googleapis.com/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/google/models/{MODEL_ID}:{stream}".format(
-            LOCATION=await location.next(),
-            PROJECT_ID=project_id,
-            MODEL_ID=original_model,
-            stream=gemini_stream
+        url = _get_vertex_model_url(
+            provider,
+            project_id,
+            "google",
+            original_model,
+            gemini_stream,
         )
 
     request_messages = copy.deepcopy(request.messages)
@@ -934,23 +926,14 @@ async def get_vertex_claude_payload(request, engine, provider, api_key=None):
 
     model_dict = get_model_dict(provider)
     original_model = model_dict[request.model]
-    if "claude-3-5-sonnet" in original_model or "claude-3-7-sonnet" in original_model or "4-5@" in original_model:
-        location = c35s
-    elif "claude-3-opus" in original_model:
-        location = c3o
-    elif "claude-sonnet-4" in original_model or "claude-opus-4" in original_model:
-        location = c4
-    elif "claude-3-sonnet" in original_model:
-        location = c3s
-    elif "claude-3-haiku" in original_model:
-        location = c3h
 
     claude_stream = "streamRawPredict"
-    url = "https://{LOCATION}-aiplatform.googleapis.com/v1/projects/{PROJECT_ID}/locations/{LOCATION}/publishers/anthropic/models/{MODEL}:{stream}".format(
-        LOCATION=await location.next(),
-        PROJECT_ID=project_id,
-        MODEL=original_model,
-        stream=claude_stream
+    url = _get_vertex_model_url(
+        provider,
+        project_id,
+        "anthropic",
+        original_model,
+        claude_stream,
     )
 
     messages = []

--- a/uni_api/routing/core.py
+++ b/uni_api/routing/core.py
@@ -105,6 +105,7 @@ def _provider_view(provider: dict, model_dict: dict, model_name: str, request_mo
         "project_id": provider.get("project_id", None),
         "private_key": provider.get("private_key", None),
         "client_email": provider.get("client_email", None),
+        "region": provider.get("region", "global"),
         "cf_account_id": provider.get("cf_account_id", None),
         "aws_access_key": provider.get("aws_access_key", None),
         "aws_secret_key": provider.get("aws_secret_key", None),


### PR DESCRIPTION

## PR description

```markdown
## Summary

This PR removes the hard-coded, model-specific Vertex AI region selection and regional round-robin behavior.

Vertex AI requests now use:

- `global` when `region` is not configured.
- The explicitly configured region when `region` is provided.
- The same region for retries instead of automatically switching regions.

Example:

```yaml
providers:
  - provider: vertex
    project_id: your-project-id
    region: us-west1
```

If `region` is omitted, it defaults to:

```yaml
region: global
```

Only a single region is currently supported. Multi-region lists and comma-separated values are intentionally not supported.

## Changes

- Removed hard-coded Vertex Gemini and Claude region selection.
- Removed automatic regional round-robin routing.
- Added the optional `region` provider configuration.
- Defaulted Vertex Gemini and Claude requests to `global`.
- Preserved `region` through provider routing views and API-key model rules.
- Added schema validation so `region` must be a string.
- Updated the English and Chinese documentation.
- Added tests for:
  - Default global region.
  - Explicit regional endpoints.
  - Vertex Gemini and Claude URL generation.
  - Region preservation through provider routing.
  - Rejection of unsupported multi-region configurations.

## Motivation

Vertex AI model availability changes over time and is not always fully reflected in the published regional availability documentation.

Automatically selecting from a hard-coded region list can therefore send requests to regions where the requested model is unavailable, resulting in intermittent `404 NOT_FOUND` responses.

Using `global` by default lets Google route supported models through the global endpoint. Users who need a specific data location or regional endpoint can configure it explicitly.

## Testing

The full local test suite passes with the database disabled:

```text
279 passed
3 skipped
0 failed
```

The change was also tested locally with Docker using:

```yaml
region: us-west1
```

`gemini-3.1-flash-lite` successfully returned responses through the configured `us-west1` endpoint.

## Risks and compatibility notes

- This changes the previous Vertex behavior: requests no longer fail over between regions automatically.
- Retries now use the same configured region. If that region is unavailable, retries will not switch to another region.
- Model availability may differ by project, account permissions, and region. Users selecting a regional endpoint are responsible for choosing a region where their models are available.
- Vertex Claude previously used model-specific regional defaults. It now also defaults to `global`. If a Claude model does not support the global endpoint, users must explicitly configure a supported region.
- Vertex Claude was covered by URL-generation and routing tests, but was not tested against live Vertex credentials.
- Existing configurations without `region` remain valid, but their effective endpoint changes to `global`.
```