### PR TITLE
fix: update broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1305,5 +1305,5 @@ Licensed under the Apache License, Version 2.0. See `LICENSE`.
 ## ⭐ Star History
 
 <a href="https://github.com/yym68686/uni-api/stargazers">
-        <img width="500" alt="Star History Chart" src="https://api.star-history.com/svg?repos=yym68686/uni-api&type=Date">
+        <img width="500" alt="Star History Chart" src="https://star-history.dera.page/svg?repos=yym68686/uni-api&type=Date">
 </a>

--- a/README_CN.md
+++ b/README_CN.md
@@ -1283,5 +1283,5 @@ python main.py
 ## ⭐ Star 历史
 
 <a href="https://github.com/yym68686/uni-api/stargazers">
-        <img width="500" alt="Star History Chart" src="https://api.star-history.com/svg?repos=yym68686/uni-api&type=Date">
+        <img width="500" alt="Star History Chart" src="https://star-history.dera.page/svg?repos=yym68686/uni-api&type=Date">
 </a>


### PR DESCRIPTION
The star history chart in the READMEs is currently broken and shows no data. This change points the chart to a working provider so contributors can see the project's growth again. No other content is modified.